### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -16,6 +16,8 @@ jobs:
   build:
     name: Build Docusaurus
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/mismasilfver-tw/pict-node-enhanced/security/code-scanning/2](https://github.com/mismasilfver-tw/pict-node-enhanced/security/code-scanning/2)

To fix the issue, we will add an explicit `permissions` block to the `build` job. Since the `build` job only needs to read the repository contents and upload artifacts, we will set the `contents` permission to `read`. This ensures that the `build` job has the minimal permissions required to perform its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
